### PR TITLE
Add Vite project setup

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="es">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>React + Radix</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "circuit-breaker",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "@radix-ui/react-dialog": "^1.0.0"
+  },
+  "devDependencies": {
+    "vite": "^5.0.0",
+    "@vitejs/plugin-react": "^4.0.0",
+    "tailwindcss": "^3.4.0",
+    "postcss": "^8.4.0",
+    "autoprefixer": "^10.0.0"
+  }
+}

--- a/postcss.config.cjs
+++ b/postcss.config.cjs
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+}

--- a/readme.md
+++ b/readme.md
@@ -1,1 +1,16 @@
-Proyecto de prueba    
+# Proyecto de prueba
+
+Este proyecto usa React, Tailwind y Radix UI con Vite.
+
+## Uso
+
+1. Instala las dependencias:
+   ```
+   npm install
+   ```
+2. Ejecuta el servidor de desarrollo:
+   ```
+   npm run dev
+   ```
+
+Abre el enlace que aparece en consola para ver la interfaz.

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,0 +1,16 @@
+import * as Dialog from '@radix-ui/react-dialog'
+
+function App() {
+  return (
+    <div className="p-6 text-center">
+      <Dialog.Root>
+        <Dialog.Trigger className="px-4 py-2 bg-blue-600 text-white rounded">Abrir diálogo</Dialog.Trigger>
+        <Dialog.Content className="p-6 bg-white rounded shadow">
+          <p>¡Hola desde Radix UI!</p>
+        </Dialog.Content>
+      </Dialog.Root>
+    </div>
+  )
+}
+
+export default App

--- a/src/index.css
+++ b/src/index.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,0 +1,10 @@
+import React from 'react'
+import ReactDOM from 'react-dom/client'
+import App from './App'
+import './index.css'
+
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+)

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -1,0 +1,10 @@
+module.exports = {
+  content: [
+    './index.html',
+    './src/**/*.{js,jsx}'
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+}

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,0 +1,6 @@
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
+
+export default defineConfig({
+  plugins: [react()],
+})


### PR DESCRIPTION
## Summary
- initialize a React project with Vite
- configure Tailwind CSS and Radix UI
- replace old HTML-only example
- update README with usage instructions

## Testing
- `npm install` *(fails: 403 Forbidden fetching packages)*


------
https://chatgpt.com/codex/tasks/task_e_688827742a308332845748eb10d1eef0